### PR TITLE
Api controllers

### DIFF
--- a/app/assets/stylesheets/discover.scss
+++ b/app/assets/stylesheets/discover.scss
@@ -3,6 +3,21 @@
 
 $header-row-color: #c9c9c9;
 
+.link-out{
+  background-color: $influence-blue;
+  border-radius: 3px;
+  border: none;
+  border-radius: 5px;
+  box-shadow: 0px 3px 6px -3px black; 
+  color: white; 
+  @include breakpoint(sm) {
+    margin-left: 5%;
+    padding: 5px 16px;
+    margin-top: 10px;
+    font-size: 18px;
+  }
+}
+
 .react-errors-container{
   position: fixed;
   top: 0;

--- a/app/assets/stylesheets/discover.scss
+++ b/app/assets/stylesheets/discover.scss
@@ -3,6 +3,28 @@
 
 $header-row-color: #c9c9c9;
 
+.react-errors-container{
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 99;
+  text-align: center;
+  background-color: $influence-red;
+  padding: 20px 0%;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  // display: none;
+
+  .message{
+    margin:0;
+    padding: 0;
+  }
+
+  .close-me{
+    font-size: 10px;
+  }
+}
+
 .discover-container{
   background-color: white;
   border-radius: 10px;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -18,4 +18,5 @@ $sm-gutters: 10%;
 $influence-orange: #ec8b4a;
 $influence-blue: #27aacf;
 $influence-green: #26c493;
+$influence-red: #e66264;
 $offer-bg: #e2e2e2;

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::OffersController < ApplicationApiController
+  protect_from_forgery only: [:claim]
+
+  def claim
+    return respond_with_error('unauthorized', nil, "Please log in to continue.") if !player_signed_in?
+    offer = Offer.find(claim_params['id'])
+    result = OfferClaimer.call(player: current_player, offer: offer)
+    render json: result
+  end
+
+  private
+
+  def claim_params
+    params.permit(:id, offer: {})
+  end
+
+end

--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -1,0 +1,17 @@
+class ApplicationApiController < ApplicationController
+  include ApiErrorHandling
+
+  rescue_from ActiveRecord::RecordNotFound do |e|
+    respond_with_error('not_found', nil, "Record was not found")
+  end  
+
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    respond_with_error('unprocessable_entity', nil, "#{e.message}")
+  end  
+
+  rescue_from ActiveRecord::RecordNotUnique do |e|
+    respond_with_error('conflict', nil, "#{e.message}")
+  end    
+
+  
+end

--- a/app/controllers/concerns/api_error_handling.rb
+++ b/app/controllers/concerns/api_error_handling.rb
@@ -1,0 +1,9 @@
+module ApiErrorHandling
+  # Generalized error handling method with flexible options for use in api controllers.
+  def respond_with_error(error, invalid_resource = nil, message = nil)
+    error = $API_ERRORS[error]
+    error['details'] = invalid_resource.errors.full_messages if invalid_resource
+    error['message'] = message if message
+    render json: error, status: error['status']
+  end
+end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -7,5 +7,7 @@ class OffersController < ApplicationController
   end
 
   def claimed
+    @player = current_player
+    @claimed_offers = @player.offers
   end
 end

--- a/app/javascript/bundles/Discover/components/Discover.jsx
+++ b/app/javascript/bundles/Discover/components/Discover.jsx
@@ -4,14 +4,12 @@ import DiscoverList from './DiscoverList'
 import { DiscoverContext } from './DiscoverContext'
 
 const Discover = (props) => {
-  // console.log(props)
   return(
-    <div className="discover-container">
+      <>
       <DiscoverContext.Provider value={props}>
-        <h3 className="discover-title">Discover Offers</h3>
         <DiscoverList/>
       </DiscoverContext.Provider>
-    </div>
+      </>
   )
 }
 

--- a/app/javascript/bundles/Discover/components/DiscoverList.jsx
+++ b/app/javascript/bundles/Discover/components/DiscoverList.jsx
@@ -20,7 +20,7 @@ const DiscoverList = () => {
       <div className="offers-list">
         {
           activeOffers.map((collection, index) => (
-            <Offer setError={setError} show={collection.show} offer={collection.offer} tags={collection.tags} key={`offer-${collection.offer.id}`}/>
+            <Offer showActions={true} setError={setError} show={collection.show} offer={collection.offer} tags={collection.tags} key={`offer-${collection.offer.id}`}/>
           ))
         }
       </div>

--- a/app/javascript/bundles/Discover/components/DiscoverList.jsx
+++ b/app/javascript/bundles/Discover/components/DiscoverList.jsx
@@ -3,21 +3,27 @@ import React, { useState, useContext } from 'react';
 import { DiscoverContext } from './DiscoverContext'
 import DiscoverForm from './DiscoverForm'
 import Offer from "./Offer"
+import ErrorDisplay from "./ErrorDisplay"
 
 const DiscoverList = () => {
   const offersData = useContext(DiscoverContext)
   const offers = offersData.offers
   const [activeOffers, setActiveOffers] = useState(offers)
+  const [error, setError] = useState("")
 
   return(
     <>
-    <DiscoverForm setActiveOffers={setActiveOffers}/>
-    <div className="offers-list">
-      {
-        activeOffers.map((collection, index) => (
-          <Offer show={collection.show} offer={collection.offer} tags={collection.tags} key={`offer-${collection.offer.id}`}/>
-        ))
-      }
+    <ErrorDisplay error={error} setError={setError}/>
+    <div className="discover-container">
+      <h3 className="discover-title">Discover Offers</h3>
+      <DiscoverForm setActiveOffers={setActiveOffers}/>
+      <div className="offers-list">
+        {
+          activeOffers.map((collection, index) => (
+            <Offer setError={setError} show={collection.show} offer={collection.offer} tags={collection.tags} key={`offer-${collection.offer.id}`}/>
+          ))
+        }
+      </div>
     </div>
     </>
   )

--- a/app/javascript/bundles/Discover/components/ErrorDisplay.jsx
+++ b/app/javascript/bundles/Discover/components/ErrorDisplay.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React, { useState, useContext } from 'react';
+
+const ErrorDisplay = ({error, setError}) => {  
+  let styles = {display: 'none'}
+  
+  if(error.length > 0){
+    styles = {}
+  }
+
+  const closeError = (event) =>{
+    event.preventDefault()
+    setError("")
+  }
+
+  return(
+
+    <div 
+      className="react-errors-container"
+      style={styles}
+      onClick={closeError}
+    >
+      <span className="message">{error}</span>
+      <br/>
+      <span className="close-me">Tap to Close</span>
+    </div>
+  )
+}
+
+export default ErrorDisplay;

--- a/app/javascript/bundles/Discover/components/Offer.jsx
+++ b/app/javascript/bundles/Discover/components/Offer.jsx
@@ -3,12 +3,38 @@ import React, { useState } from 'react';
 
 const Offer = ({offer, tags, show}) =>{
   // console.log(tags)
+  const unclaimedButtonData = {text: "Claim", disabled: false, claimed: false}
+  const claimedButtonData = {text: "Claimed!", disabled: true, claimed: true}
+  const pendingButtonData = {text: "Claiming...", disabled: true, claimed: false}
+  const [buttonState, setButtonState] = useState(unclaimedButtonData)
 
   const claimClickHandler = (event) =>{
     event.preventDefault()
     // console.log(event)
-    event.target.disabled = true
-    event.target.innerHTML = "Claimed!"
+    // event.target.disabled = true
+    // event.target.innerHTML = "Claimed!"
+    postClaimOffer()
+  }
+
+  const postClaimOffer = async () =>{
+    const location = `${window.location.protocol}//${window.location.host}`
+    const url = `${location}/api/v1/offers/${offer.id}/claim`
+    const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute("content")
+    console.log(url)
+    const body = {
+      method: "POST",
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrf,
+      }
+    }
+    try {
+      const response = await fetch(url, body)
+      const data = await response.json();
+      return data
+    } catch(e) {
+      return e
+    }
   }
 
   if(show){
@@ -22,7 +48,14 @@ const Offer = ({offer, tags, show}) =>{
           ))}      
         </div>
         <hr/>
-        <button data-offer-id={offer.id} onClick={claimClickHandler} className="claim-button">Claim</button>
+        <button 
+          data-offer-id={offer.id} 
+          onClick={claimClickHandler} 
+          className="claim-button"
+          disabled={buttonState.disabled}
+        >
+          {buttonState.text}
+        </button>
 
       </div>
     )    

--- a/app/javascript/bundles/Discover/components/Offer.jsx
+++ b/app/javascript/bundles/Discover/components/Offer.jsx
@@ -1,12 +1,18 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
-const Offer = ({offer, tags, show, setError}) =>{
+const Offer = ({offer, tags, show, setError, showActions}) =>{
   // console.log(tags)
   const unclaimedButtonData = {text: "Claim", disabled: false, claimed: false}
   const claimedButtonData = {text: "Claimed!", disabled: true, claimed: true}
   const pendingButtonData = {text: "Claiming...", disabled: true, claimed: false}
   const [buttonState, setButtonState] = useState(unclaimedButtonData)
+
+  let buttonDisplay = {display: 'none'}
+  if(showActions){
+    buttonDisplay = {}
+  }
+
 
   const claimClickHandler = (event) => {
     event.preventDefault()
@@ -80,15 +86,18 @@ const Offer = ({offer, tags, show, setError}) =>{
             <span key={tag.slug} className="tag">{tag.name}</span> 
           ))}      
         </div>
-        <hr/>
-        <button 
-          data-offer-id={offer.id} 
-          onClick={claimClickHandler} 
-          className="claim-button"
-          disabled={buttonState.disabled}
-        >
-          {buttonState.text}
-        </button>
+
+        <div style={buttonDisplay}>
+          <hr/>
+          <button 
+            data-offer-id={offer.id} 
+            onClick={claimClickHandler} 
+            className="claim-button"
+            disabled={buttonState.disabled}
+          >
+            {buttonState.text}
+          </button>
+        </div>
 
       </div>
     )    

--- a/app/javascript/bundles/Discover/components/Offer.jsx
+++ b/app/javascript/bundles/Discover/components/Offer.jsx
@@ -1,26 +1,58 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
-const Offer = ({offer, tags, show}) =>{
+const Offer = ({offer, tags, show, setError}) =>{
   // console.log(tags)
   const unclaimedButtonData = {text: "Claim", disabled: false, claimed: false}
   const claimedButtonData = {text: "Claimed!", disabled: true, claimed: true}
   const pendingButtonData = {text: "Claiming...", disabled: true, claimed: false}
   const [buttonState, setButtonState] = useState(unclaimedButtonData)
 
-  const claimClickHandler = (event) =>{
+  const claimClickHandler = (event) => {
     event.preventDefault()
-    // console.log(event)
-    // event.target.disabled = true
-    // event.target.innerHTML = "Claimed!"
-    postClaimOffer()
+    const response = postClaimOffer()
+    response.then((res) => (
+      handleClaimResponse(res)
+    ))
   }
 
-  const postClaimOffer = async () =>{
+  const delegateButtonState = (stateToSet) => {
+    const buttonStates = {
+      "claimed": claimedButtonData,
+      "pending": pendingButtonData,
+      "unclaimed": unclaimedButtonData
+    }
+    setButtonState(buttonStates[stateToSet])
+  }
+
+  const handleClaimResponse = (res) =>{
+    if(res.status){
+      switch(res.status){
+        case '409':
+          setError('You have already claimed this offer.')
+          delegateButtonState("claimed")
+          break;
+        case '401':
+          setError('Sign in again to continue.')
+          delegateButtonState("unclaimed")
+          break;
+        case '403':
+          setError('An error has occured. Refresh the page and try again.')
+          delegateButtonState("unclaimed")
+          break;
+        default:
+          setError(res.message)
+      }
+    } else {
+      delegateButtonState("claimed")
+      return res
+    }
+  }
+
+  const postClaimOffer = async (event) =>{
     const location = `${window.location.protocol}//${window.location.host}`
     const url = `${location}/api/v1/offers/${offer.id}/claim`
     const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute("content")
-    console.log(url)
     const body = {
       method: "POST",
       headers: {
@@ -29,11 +61,12 @@ const Offer = ({offer, tags, show}) =>{
       }
     }
     try {
+      delegateButtonState("pending")
       const response = await fetch(url, body)
       const data = await response.json();
       return data
-    } catch(e) {
-      return e
+    } catch (error) {
+      return error
     }
   }
 

--- a/app/javascript/packs/discover-bundle.js
+++ b/app/javascript/packs/discover-bundle.js
@@ -1,8 +1,10 @@
 import ReactOnRails from 'react-on-rails';
 
 import Discover from '../bundles/Discover/components/Discover';
+import Offer from '../bundles/Discover/components/Offer';
 
 // This is how react_on_rails can see the HelloWorld in the browser.
 ReactOnRails.register({
   Discover,
+  Offer
 });

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,7 @@
+# Base with added functionality for more functional style and the ability to forego class instantiation.
+class ApplicationService
+  # Used as the defaut case when ApplicationService is used in other code. Provides a flexible interface with block. 
+  def self.call(*args, &block)
+    new(*args, &block).call
+  end
+end

--- a/app/services/offer_claimer.rb
+++ b/app/services/offer_claimer.rb
@@ -1,0 +1,10 @@
+class OfferClaimer < ApplicationService
+  def self.call(player:, offer:)
+    if player.offers << offer
+      offer.increment(:total_claimed, by = 1)
+      offer.save!
+    end
+    response = Struct.new(:player, :offer)
+    return response.new(player, offer)
+  end
+end

--- a/app/views/offers/claimed.html.erb
+++ b/app/views/offers/claimed.html.erb
@@ -1,2 +1,18 @@
-<%= button_to "Continue Discovering", discover_path, method: :get, class: "view-claimed" %>
-<h1> Claimed Page </h1>
+<%= button_to "Continue Discovering", discover_path, method: :get, class: "link-out" %>
+
+<div class="discover-container">
+  <h3 class="discover-title">Claimed Offers</h3>
+  <div class="offers-list">
+    <% @claimed_offers.each do |offer| %>
+      <%= react_component("Offer", 
+      props: {
+        showActions: false, 
+        show: true, 
+        offer: offer, 
+        tags: offer.tags,
+        key: "offer-#{offer.id}"
+      }, 
+      prerender: false) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/offers/discover.html.erb
+++ b/app/views/offers/discover.html.erb
@@ -1,3 +1,3 @@
-<%= button_to "View Claimed Offers", claimed_offers_path, method: :get, class: "view-claimed" %>
+<%= button_to "View Claimed Offers", claimed_offers_path, method: :get, class: "link-out" %>
 
 <%= react_component("Discover", props: {offers: @offers, tags: @tags}, prerender: false) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module InfluenceOffers
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
     config.autoload_paths += Dir[Rails.root.join('app', 'models', '{**}')]
+    config.autoload_paths += Dir[Rails.root.join('app', 'services', '{**}')]
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/error_codes.yml
+++ b/config/error_codes.yml
@@ -1,0 +1,37 @@
+api:
+  invalid_resource:
+    code: '1'
+    status: '400'
+    title: 'Bad Request'
+  unprocessable_entity:
+    code: '2'
+    status: '422'
+    title: 'Unprocessable Entity'
+  unauthorized:
+    code: '3'
+    status: '401'
+    title: 'Unauthorized'
+  not_found:
+    code: '4'
+    status: '400'
+    title: "Not Found"
+  standard_error:
+    code: '5'
+    status: '500'
+    title: 'Standard Error'
+  session_expired:
+    code: '6'
+    status: '440'
+    title: 'Session Expired'
+  request_timeout:
+    code: '7'
+    status: '408'
+    title: "Request Timeout"
+  forbidden:
+    code: '8'
+    status: '403'
+    title: "Forbidden"
+  conflict:
+    code: '9'
+    status: '409'
+    title: 'Conflict'

--- a/config/initializers/api_errors.rb
+++ b/config/initializers/api_errors.rb
@@ -1,0 +1,1 @@
+$API_ERRORS = YAML.load_file(Rails.root.join('config','error_codes.yml'))['api']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,12 @@ Rails.application.routes.draw do
   devise_for :players, :controllers => { registrations: 'players/registrations' }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  namespace :api do 
+    namespace :v1 do 
+      post "offers/:id/claim", to: 'offers#claim', as: :offer_claim
+    end
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/spec/controllers/api/application_api_controller_spec.rb
+++ b/spec/controllers/api/application_api_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationApiController do
+
+  describe "modules" do 
+    it "contains the ApiErrorHandling module" do
+      expect(ApplicationApiController.include?(ApiErrorHandling)).to eq(true)
+    end
+  end   
+
+  describe 'constant dependencies' do 
+    it "loads the API_ERRORS constant" do 
+      expect(!!$API_ERRORS).to eq(true)
+    end
+  end  
+end

--- a/spec/controllers/api/offers_controller_spec.rb
+++ b/spec/controllers/api/offers_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::OffersController, type: :request do
+
+  before(:each) do
+    @offer = FactoryBot.create(:new_offer)
+    @player = FactoryBot.create(:new_player)
+
+    Warden.test_mode!
+    login_as(@player, scope: :player)
+
+    @headers = { "Content-Type" => "application/json" }
+    allow(Api::V1::OffersController).to receive(:protect_from_forgery).and_return(false)
+  end
+
+  after(:each) do 
+    Warden.test_reset!
+  end
+
+  it "will claim an offer" do 
+    post(api_v1_offer_claim_url(@offer.id), headers: @headers)
+    res = JSON.parse(response.body)
+    expect(res["player"]["id"]).to eq(@player.id)
+    expect(res["offer"]["id"]).to eq(@offer.id)
+
+    @offer.reload
+    expect(@offer.total_claimed > 0).to eq(true)
+    expect(@player.offers.include?(@offer)).to eq(true)
+  end
+
+  context "error cases" do
+    it "will 409 on duplicate offer claim" do 
+      post(api_v1_offer_claim_url(@offer.id), headers: @headers)
+      post(api_v1_offer_claim_url(@offer.id), headers: @headers)
+      res = JSON.parse(response.body)
+      expect(response.status).to eq(409)
+      expect(res['title']).to eq('Conflict')
+    end
+
+    it "will 401 on no session" do 
+      logout(:player)
+      post(api_v1_offer_claim_url(@offer.id), headers: @headers)
+      res = JSON.parse(response.body)
+      expect(response.status).to eq(401)
+      expect(res['title']).to eq('Unauthorized')
+    end
+
+    it "will 400 on invalid offer id" do 
+      post(api_v1_offer_claim_url(9999999999), headers: @headers)
+      res = JSON.parse(response.body)
+      expect(response.status).to eq(400)
+      expect(res['title']).to eq('Not Found')
+    end
+  end
+
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,13 +43,17 @@ RSpec.configure do |config|
   # This will use the defaults of :js and :server_rendering meta tags
   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
 
+  # config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Warden::Test::Helpers, type: :request
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]
 
-  config.before(:all) do
-    DatabaseCleaner.clean
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
   end    
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/services/offer_claimer_spec.rb
+++ b/spec/services/offer_claimer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "offer_claimer service" do
+  before(:each) do 
+    @player = FactoryBot.create(:new_player)
+    @offer = FactoryBot.create(:new_offer)
+  end
+
+  it "will claim an offer" do 
+    result = OfferClaimer.call(player: @player, offer: @offer)
+    expect(@offer.total_claimed > 0).to eq(true)
+    expect(@player.offers.include?(@offer)).to eq(true)
+    expect(@offer.players.include?(@player)).to eq(true)
+  end
+
+  it "will not claim duplicate offers" do 
+    OfferClaimer.call(player: @player, offer: @offer)
+    expect{OfferClaimer.call(player: @player, offer: @offer)}.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+end


### PR DESCRIPTION
This merge adds the api controller and the route for claiming offers.

It also includes React error handling for the API call and relevant UI compoment to display errors.

Also put in the Offers list view really quick and styled the buttons taking you between that page and the Suggest page. 

I added some extra tooling to the Api controller setup. This is very similar to how I've done error handling in the past and includes some simple but powerful abstractions to make you have to write far less controller code and maintain consistency once you start adding more routes/actions. 