### PR TITLE
Suggestions api

### DIFF
--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::SuggestionsController < ApplicationApiController
+  protect_from_forgery
+
+  def suggest
+    ap suggestion_params
+    player = Player.find(suggestion_params[:player_id])
+    suggestions = SuggestionGenerator.new(player).suggestions
+    offers = OffersFormatter.from_suggestions(suggestions)
+    # return respond_with_error('unauthorized', nil, "Please log in to continue.") if !player_signed_in?
+    # offer = Offer.find(claim_params['id'])
+    # result = OfferClaimer.call(player: current_player, offer: offer)
+    render json: offers
+  end
+
+  private
+
+  def suggestion_params
+    params.permit(:player_id, suggestion:{})
+  end
+
+end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -9,7 +9,7 @@ class OffersController < ApplicationController
       @offers = OffersFormatter.from_suggestions(suggestions)
     end
     # @offers = Offer.preload(:tags).first(100).map {|offer| {offer: offer, tags: offer.tags.sort_by(&:name), show: true}}
-
+    @player = current_player
     @tags = Tag.all
   end
 

--- a/app/javascript/bundles/Discover/components/DiscoverForm.jsx
+++ b/app/javascript/bundles/Discover/components/DiscoverForm.jsx
@@ -3,10 +3,15 @@ import React, { useState, useContext } from 'react';
 import Select from 'react-select';
 import { DiscoverContext } from './DiscoverContext'
 
-const DiscoverForm = ({setActiveOffers}) => {
+const DiscoverForm = ({setActiveOffers, setError}) => {
+  const suggestButtonData = {text: "Suggest!", disabled: false}
+  const suggestButtonDisabledData = {text: "Suggesting...", disabled: true}
+  const [suggestButtonState, setSuggestButtonState] = useState(suggestButtonData)
+
   const offersData = useContext(DiscoverContext)
   const [selectedOption, setSelectedOption] = useState([]);
 
+  const player = offersData.player
   const tags = offersData.tags
   const offers = offersData.offers
 
@@ -18,27 +23,70 @@ const DiscoverForm = ({setActiveOffers}) => {
     event.preventDefault()
   }
 
-  const resetOfferShow = ()=>{
-    const resetOffers = offers
-    resetOffers.forEach((offer)=>(
-      offer.show = true   
-    ))
-    setActiveOffers(resetOffers)
-  }
-
-  const handleFilterClick = (event) =>{
-    event.preventDefault()
-    if(selectedOption.length){
-      handleTagFilterChange()  
+  // SUGGESTIONS
+  const handleSuggestionResponse = (res) =>{
+    if(res.status){
+      switch(res.status){
+        case '409':
+          setError('You have already claimed this offer.')
+          delegateButtonState("claimed")
+          break;
+        case '401':
+          setError('Sign in again to continue.')
+          delegateButtonState("unclaimed")
+          break;
+        case '403':
+          setError('An error has occured. Refresh the page and try again.')
+          delegateButtonState("unclaimed")
+          break;
+        default:
+          setError(res.message)
+      }
     } else {
-      resetOfferShow()
-    } 
+      if(res.length > 0){
+        setActiveOffers(res)
+      } else {
+        setError("No offers were found that could be suggested")
+      }
+      
+      setSuggestButtonState(suggestButtonData)
+      return res
+    }    
   }
 
-  function refreshPage() {
-    window.location.reload(false);
-  }  
+  const suggestionClickHandler = (event) =>{
+    event.preventDefault()
+    const response = getPlayerOfferSuggestions()
+    response.then((res) => (
+      handleSuggestionResponse(res)
+    ))
 
+  }
+
+  const getPlayerOfferSuggestions = async () =>{
+    const location = `${window.location.protocol}//${window.location.host}`
+    const url = `${location}/api/v1/suggestions/${player.id}`
+    const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute("content")
+    const body = {
+      method: "GET",
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrf,
+      }
+    }
+    try{
+      setSuggestButtonState(suggestButtonDisabledData)
+      const response = await fetch(url, body)
+      const data = await response.json();
+      return data
+    } catch (error) {
+      setError(error.message)
+      return error
+    }    
+
+  }
+
+  // TAG FILTERING
   const handleTagFilterChange = (event) => {
     const newOffersData = []
     const selectedTags = []
@@ -61,13 +109,32 @@ const DiscoverForm = ({setActiveOffers}) => {
     setActiveOffers(newOffersData)
   }
 
+  const resetOfferShow = ()=>{
+    const resetOffers = offers
+    resetOffers.forEach((offer)=>(
+      offer.show = true   
+    ))
+    setActiveOffers(resetOffers)
+  }
+
+  const handleFilterClick = (event) =>{
+    event.preventDefault()
+    if(selectedOption.length){
+      handleTagFilterChange()  
+    } else {
+      resetOfferShow()
+    } 
+  }  
+
   return(
     <form onSubmit={handleSubmit} className="discover-form">
       <p>The more you claim, the better the suggestions!</p>
-      <button onClick={refreshPage} className="suggest-button">Suggest!</button>
+      <button 
+        onClick={suggestionClickHandler} 
+        className="suggest-button"
+        disabled={suggestButtonState.disabled}
+      >{suggestButtonState.text}</button>
       <hr/>
-      {/*<label htmlFor="discover_form">Search</label>*/}
-      {/*<input type="text" id="discover_form"/>*/}
       <Select
         defaultValue={selectedOption}
         onChange={setSelectedOption}

--- a/app/javascript/bundles/Discover/components/DiscoverList.jsx
+++ b/app/javascript/bundles/Discover/components/DiscoverList.jsx
@@ -16,11 +16,19 @@ const DiscoverList = () => {
     <ErrorDisplay error={error} setError={setError}/>
     <div className="discover-container">
       <h3 className="discover-title">Discover <span className="orange-text">Offers</span></h3>
-      <DiscoverForm setActiveOffers={setActiveOffers}/>
+      <DiscoverForm setError={setError} setActiveOffers={setActiveOffers}/>
       <div className="offers-list">
         { 
           activeOffers.length > 0 && activeOffers.map((collection, index) => (
-            <Offer showActions={true} setError={setError} show={collection.show} offer={collection.offer} tags={collection.tags} key={`offer-${collection.offer.id}`}/>
+            <Offer 
+              showActions={true} 
+              setError={setError} 
+              show={collection.show} 
+              offer={collection.offer} 
+              tags={collection.tags} 
+              suggestionMetrics={{...collection.contribution, total_weight: collection.weight, title: collection.offer.title}} 
+              key={`offer-${collection.offer.id}`}
+            />
           ))          
         }
         {

--- a/app/javascript/bundles/Discover/components/Offer.jsx
+++ b/app/javascript/bundles/Discover/components/Offer.jsx
@@ -78,7 +78,7 @@ const Offer = ({offer, tags, show, setError, showActions, suggestionMetrics}) =>
 
   const logSuggestionData = () =>{
     console.info(`Suggestion Weight Data for: ${suggestionMetrics.title}`)
-    console.log(suggestionMetrics)
+    console.log({...suggestionMetrics, offer: offer})
   }
 
   if(show){

--- a/app/javascript/bundles/Discover/components/Offer.jsx
+++ b/app/javascript/bundles/Discover/components/Offer.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
-const Offer = ({offer, tags, show, setError, showActions}) =>{
+const Offer = ({offer, tags, show, setError, showActions, suggestionMetrics}) =>{
   // console.log(tags)
   const unclaimedButtonData = {text: "Claim", disabled: false, claimed: false}
   const claimedButtonData = {text: "Claimed!", disabled: true, claimed: true}
@@ -76,9 +76,14 @@ const Offer = ({offer, tags, show, setError, showActions}) =>{
     }
   }
 
+  const logSuggestionData = () =>{
+    console.info(`Suggestion Weight Data for: ${suggestionMetrics.title}`)
+    console.log(suggestionMetrics)
+  }
+
   if(show){
     return(
-      <div className="offer">
+      <div onClick={logSuggestionData} className="offer">
         <h5 className="offer-title">{offer.title}</h5>
         <p className="offer-description">{offer.description}</p>
         <div className="tag-container">

--- a/app/javascript/packs/hello-world-bundle.js
+++ b/app/javascript/packs/hello-world-bundle.js
@@ -1,8 +1,8 @@
-import ReactOnRails from 'react-on-rails';
+// import ReactOnRails from 'react-on-rails';
 
-import HelloWorld from '../bundles/HelloWorld/components/HelloWorld';
+// import HelloWorld from '../bundles/HelloWorld/components/HelloWorld';
 
-// This is how react_on_rails can see the HelloWorld in the browser.
-ReactOnRails.register({
-  HelloWorld,
-});
+// // This is how react_on_rails can see the HelloWorld in the browser.
+// ReactOnRails.register({
+//   HelloWorld,
+// });

--- a/app/javascript/packs/server-bundle.js
+++ b/app/javascript/packs/server-bundle.js
@@ -1,8 +1,10 @@
 import ReactOnRails from 'react-on-rails';
 
-import HelloWorld from '../bundles/HelloWorld/components/HelloWorldServer';
+import Discover from '../bundles/Discover/components/Discover';
+import Offer from '../bundles/Discover/components/Offer';
 
 // This is how react_on_rails can see the HelloWorld in the browser.
 ReactOnRails.register({
-  HelloWorld,
+  Discover,
+  Offer
 });

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -10,19 +10,19 @@ class Offer < ApplicationRecord
 
   validates :target_age, presence: true
   validates :target_age, numericality: {in: AGE_BOUNDS}
+
+  validates :max_age, presence: true
   validates :max_age, numericality: {in: AGE_BOUNDS}
+
+  validates :min_age, presence: true
   validates :min_age, numericality: {in: AGE_BOUNDS}
 
   validates :target_gender, presence: true
   validates :target_gender, inclusion: {in: GENDERS, message: "Invalid gender specified"}  
 
-  before_validation :assign_default_max_and_min
-  
-  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
-  # NEED TO ADD A BEFORE SAVE TO CHECK IF THE target_age is in between min and max!
-  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
-
   # Using dependent: :destroy to keep data cleaner in the scope of this app.
+  # Might leave this in for metrics in larger apps (or add soft delete or something), 
+  # but we aren't running metrics here and it makes dealing with the data far easier.
   has_many :claimed_offers, dependent: :destroy
   has_many :players, through: :claimed_offers
 
@@ -30,25 +30,8 @@ class Offer < ApplicationRecord
   has_many :tags, through: :offer_tags
 
   scope :targeting, ->(gender){ where(target_gender: gender)}
-  scope :not_targeting, ->(gender){ where("target_gender != ?", gender)}
-
+  scope :not_targeting, ->(gender){where("target_gender != ?", gender)}
   scope :in_age_range, ->(age){where("min_age <= ? AND max_age >= ?", age, age)}
 
-  private
-
-  # I am doing this to ensure that there is always a range to work with.
-  # The UI on the backend will see it as required, but I don't want
-  # a wayward expectation to leave nil columns. 1 in each direction seems reasonable even 
-  # if they were trying to specifically target 18 year old high school seniors or something.
-  # Something something birthday math...
-
-  # I really just did this for data consitency, as they aren't strictly "required" but
-  # greatly simplifies the Suggestion system from edge casing when I go to build it too.
-  def assign_default_max_and_min
-    if target_age
-      self.max_age = (target_age + 1) if max_age.nil?
-      self.min_age = (target_age - 1) if min_age.nil?
-    end
-  end
 
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -12,12 +12,11 @@ class Player < ApplicationRecord
   validates :age, presence: true
   validates :age, numericality: {in: AGE_RANGE}
 
-  # Using dependent: :destroy to keep data cleaner for this situation.
+  # Using dependent: :destroy to keep data cleaner in the scope of this app.
+  # Might leave this in for metrics in larger apps (or add soft delete or something), 
+  # but we aren't running metrics here and it makes dealing with the data far easier.  
   has_many :claimed_offers, dependent: :destroy
   has_many :offers, through: :claimed_offers
-
-  # scope :claimed_offers, -> {joins(:claimed_offers).where('player_id = player.id')}
-
 
   # private
   # def ransackable_associations(auth_object = nil)

--- a/app/services/suggestions/suggestion_generator.rb
+++ b/app/services/suggestions/suggestion_generator.rb
@@ -96,8 +96,8 @@ class SuggestionGenerator < ApplicationService
       seed = (inner_diff.to_f / total_range.to_f) # 0.6
     end
 
-    score = (1 - seed)
-    weight = (score * 10).floor
+    score = (1 - seed) # grabs inverse diff, max: .8, min: .4
+    weight = (score * 10).floor # makes it into a whole number < 10
     return weight
   end
 

--- a/app/services/suggestions/suggestion_generator.rb
+++ b/app/services/suggestions/suggestion_generator.rb
@@ -1,6 +1,6 @@
 class SuggestionGenerator < ApplicationService
 
-  attr_reader :relevant_offers, :claimed_offers, :offer_weights
+  attr_reader :offer_weights
 
   alias_method :suggestions, :offer_weights
 
@@ -13,6 +13,8 @@ class SuggestionGenerator < ApplicationService
 
     generate_weights
   end
+
+  private
 
   # SETUP & TOTAL CLAIMED OFFERS
   def build_weight_structs
@@ -74,8 +76,6 @@ class SuggestionGenerator < ApplicationService
 
   # AGE
   def calc_age_range_weight(offer)
-    # Was going to do this in ternary, but it's super hard to read that way.
-    # So I just laid it out...
     # Can probably do this with .abs, but this solution
     # is how I whiteboarded it and works well.
     age_diff = (@player.age - offer.target_age)

--- a/app/services/suggestions/suggestion_generator.rb
+++ b/app/services/suggestions/suggestion_generator.rb
@@ -53,7 +53,7 @@ class SuggestionGenerator < ApplicationService
     offer = weight_data.offer
     offer.tags.each do |tag|
       if @tag_frequencies.key?(tag.id)
-        total_weight = (@tag_frequencies[tag.id] / offer.tags.length)
+        total_weight = ((@tag_frequencies[tag.id] / offer.tags.length) * 0.5).round
         weight_data.contribution[:tags] += total_weight
         weight_data.weight += total_weight
       end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,10 +7,8 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application" %>
-
-
     <%= javascript_pack_tag 'discover-bundle' %>
-    <%= stylesheet_pack_tag 'hello-world-bundle' %>    
+   
   </head>
 
   <body>

--- a/app/views/offers/claimed.html.erb
+++ b/app/views/offers/claimed.html.erb
@@ -10,7 +10,8 @@
         show: true, 
         offer: offer, 
         tags: offer.tags,
-        key: "offer-#{offer.id}"
+        key: "offer-#{offer.id}",
+        suggestionMetrics: {title: offer.title}
       }, 
       prerender: false) %>
     <% end %>

--- a/app/views/offers/discover.html.erb
+++ b/app/views/offers/discover.html.erb
@@ -1,3 +1,3 @@
 <%= button_to "View Claimed Offers", claimed_offers_path, method: :get, class: "link-out" %>
 
-<%= react_component("Discover", props: {offers: @offers, tags: @tags}, prerender: false) %>
+<%= react_component("Discover", props: {offers: @offers, tags: @tags, player: @player}, prerender: false) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api do 
     namespace :v1 do 
       post "offers/:id/claim", to: 'offers#claim', as: :offer_claim
+      get "suggestions/:player_id", to: 'suggestions#suggest', as: :player_offers_suggestions
     end
   end
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -20,39 +20,6 @@ RSpec.describe Offer, type: :model do
     it {should have_many(:tags)}
   end
 
-  describe "before_validation" do 
-
-    before(:each) do 
-      # If no min_age or max_age - should call #assign_default_max_and_min on validation
-      @offer = Offer.new(title: "Incomplete Offer", description:"Incomplete", target_age: 30)
-    end
-
-    context "ranges" do 
-      it "will assign a default max_age" do 
-        @offer.save
-        expect(@offer.max_age).to eq(@offer.target_age + 1)
-      end
-
-      it "will assign a default min_age" do 
-        @offer.save
-        expect(@offer.min_age).to eq(@offer.target_age - 1)        
-      end  
-
-      context 'defaults with #assign_default_max_and_min' do 
-        it "will not assign max_age if out of range" do 
-          @offer.target_age = 125
-          expect{@offer.save!}.to raise_error(ActiveRecord::RecordInvalid)
-        end  
-
-        it "will not assign min_age if out of range" do 
-          @offer.target_age = 1
-          expect{@offer.save!}.to raise_error(ActiveRecord::RecordInvalid)
-        end           
-      end
-     
-    end 
-  end  
-
   describe 'validations' do 
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:target_age) }
@@ -60,8 +27,13 @@ RSpec.describe Offer, type: :model do
     it { should validate_length_of(:title) }
     it { should validate_length_of(:description) }
     
+    it { should validate_presence_of(:target_age) }
     it { should validate_numericality_of(:target_age) }
+
+    it { should validate_presence_of(:max_age) }
     it { should validate_numericality_of(:max_age) }
+
+    it { should validate_presence_of(:min_age) }
     it { should validate_numericality_of(:min_age) }
 
     before(:each) do 

--- a/spec/views/auth/auth_spec.rb
+++ b/spec/views/auth/auth_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "front page", type: :feature do
         fill_in 'Password confirmation', with: 'password'
         fill_in 'Age', with: 35
       end
-      click_button 'Sign up'
+      click_button 'SIGN UP'
       expect(page).to have_content 'Welcome! You have signed up successfully.'
     end
 
@@ -24,7 +24,7 @@ RSpec.describe "front page", type: :feature do
         fill_in 'Password confirmation', with: 'password'
         fill_in 'Age', with: 35
       end
-      click_button 'Sign up'
+      click_button 'SIGN UP'
       expect(page).to have_content "Email can't be blank"
     end     
 
@@ -33,7 +33,7 @@ RSpec.describe "front page", type: :feature do
         fill_in 'Email', with: Faker::Internet.email
         fill_in 'Age', with: 35
       end
-      click_button 'Sign up'
+      click_button 'SIGN UP'
       expect(page).to have_content "Password can't be blank"
     end    
 
@@ -43,7 +43,7 @@ RSpec.describe "front page", type: :feature do
         fill_in 'Password', with: 'password'
         fill_in 'Password confirmation', with: 'password'
       end
-      click_button 'Sign up'
+      click_button 'SIGN UP'
       expect(page).to have_content "Age can't be blank"
     end
 
@@ -51,13 +51,13 @@ RSpec.describe "front page", type: :feature do
       within('#new_player') do 
         fill_in 'Age', with: 200
       end  
-      click_button 'Sign up'  
+      click_button 'SIGN UP'  
       expect(page).to have_content 'Age must be in 1..125'  
 
       within('#new_player') do 
         fill_in 'Age', with: 0
       end     
-      click_button 'Sign up'  
+      click_button 'SIGN UP'  
       expect(page).to have_content 'Age must be in 1..125'         
     end      
   end


### PR DESCRIPTION
AJAX suggestions are in!

Added the ability to click on an offer and get a `console.log()` of the offer suggestion data. Helps with view auditing and lets the dev see the weights without having to log it all. Helps with demo purposes too...

Cleaned up a lot of comments. 

Cleaned up convoluted `before_validation` callback in Offers.

Reduced Tag weights in suggestions.