### PR TITLE
added multiple genders option to offers

### DIFF
--- a/app/admin/offers.rb
+++ b/app/admin/offers.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register Offer do
       f.input :min_age
       f.input :max_age
 
-      f.input :target_gender, :as => :select, collection: Offer::GENDERS, input_html: {style:'width:40%'}
+      f.input :target_genders, :as => :select, collection: Gender.all, input_html: {style:'width:40%'}
       f.input :tags, :as => :select, collection: Tag.all, input_html: {style:'width:40%;height: 100px;'}
     end
     

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -2,12 +2,8 @@ class OffersController < ApplicationController
   before_action :authenticate_player!
 
   def discover
-    if current_player.offers.length == 0
-      @offers = OffersFormatter.from_base(Offer.preload(:tags).first(100))
-    else
-      suggestions = SuggestionGenerator.new(current_player).suggestions
-      @offers = OffersFormatter.from_suggestions(suggestions)
-    end
+    suggestions = SuggestionGenerator.new(current_player).suggestions
+    @offers = OffersFormatter.from_suggestions(suggestions)
     @player = current_player
     @tags = Tag.all
   end

--- a/app/models/associations/offer_gender.rb
+++ b/app/models/associations/offer_gender.rb
@@ -1,0 +1,4 @@
+class OfferGender < ApplicationRecord
+  belongs_to :gender
+  belongs_to :offer
+end

--- a/app/models/gender.rb
+++ b/app/models/gender.rb
@@ -1,0 +1,13 @@
+class Gender < ApplicationRecord
+  GENDERS = ["male", "female", "nonbinary", "declined"].freeze
+  LABELS = ["Male", "Female", "Non-Binary", "Declined to Answer"].freeze
+
+  validates :name, presence: true
+  validates :name, inclusion: {in: GENDERS, message: "Invalid gender specified"}  
+
+  validates :label, presence: true
+  validates :label, inclusion: {in: LABELS, message: "Invalid gander label specified"}  
+
+  has_many :offer_genders, dependent: :destroy
+  has_many :offers, through: :offer_genders  
+end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,7 +1,7 @@
 class Offer < ApplicationRecord
 
   AGE_BOUNDS = 1..125
-  GENDERS = ["male", "female", "nonbinary", "declined"].freeze
+  # GENDERS = ["male", "female", "nonbinary", "declined"].freeze
 
   validates :title, presence: true
   validates :title, length: {maximum: 80}
@@ -18,8 +18,8 @@ class Offer < ApplicationRecord
   validates :min_age, presence: true
   validates :min_age, numericality: {in: AGE_BOUNDS}
 
-  validates :target_gender, presence: true
-  validates :target_gender, inclusion: {in: GENDERS, message: "Invalid gender specified"}  
+  # validates :target_gender, presence: true
+  # validates :target_gender, inclusion: {in: GENDERS, message: "Invalid gender specified"}  
 
   # Using dependent: :destroy to keep data cleaner in the scope of this app.
   # Might leave this in for metrics in larger apps (or add soft delete or something), 
@@ -30,8 +30,11 @@ class Offer < ApplicationRecord
   has_many :offer_tags, dependent: :destroy
   has_many :tags, through: :offer_tags
 
-  scope :targeting, ->(gender){ where(target_gender: gender)}
-  scope :not_targeting, ->(gender){where("target_gender != ?", gender)}
+  has_many :offer_genders, dependent: :destroy
+  has_many :target_genders, through: :offer_genders, :source => 'gender'
+
+  # scope :targeting, ->(gender){ where(target_gender: gender)}
+  # scope :not_targeting, ->(gender){where("target_gender != ?", gender)}
   scope :in_age_range, ->(age){where("min_age <= ? AND max_age >= ?", age, age)}
 
   # I originally went with a counted version that used before_save/incrementors to store the count in a column

--- a/app/services/offers_formatter.rb
+++ b/app/services/offers_formatter.rb
@@ -28,7 +28,8 @@ class OffersFormatter < ApplicationService
         tags: offer_data.offer.tags.sort_by(&:name),
         show: true,
         weight: offer_data.weight,
-        contribution: offer_data.contribution
+        contribution: offer_data.contribution,
+        genders: offer_data.offer.target_genders
       }
     end
   end

--- a/app/services/suggestions/suggestion_generator.rb
+++ b/app/services/suggestions/suggestion_generator.rb
@@ -27,7 +27,8 @@ class SuggestionGenerator < ApplicationService
         tags: 0, 
         gender: 0, 
         age: 0, 
-        claimed: offer.total_claimed
+        claimed: offer.total_claimed,
+        included_genders: offer.target_genders.map(&:label)
       })
     end
   end
@@ -63,15 +64,10 @@ class SuggestionGenerator < ApplicationService
   end
 
   # GENDER
-  def gender_weighted?
-    ['male', 'female'].include?(@player.gender)
-  end
 
   def weigh_gender(weight_data)
     offer = weight_data.offer
-    if gender_weighted?
-      (weight_data.weight += 10 && weight_data.contribution[:gender] += 10) if offer.target_gender == @player.gender
-    end
+    (weight_data.weight += 10 && weight_data.contribution[:gender] += 10) if offer.target_genders.map(&:name).include?(@player.gender)
   end
 
   # AGE

--- a/db/migrate/20231218103529_create_genders.rb
+++ b/db/migrate/20231218103529_create_genders.rb
@@ -1,0 +1,15 @@
+class CreateGenders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :genders do |t|
+      t.string :name
+      t.string :label
+      t.timestamps
+    end
+
+    create_table :offer_genders do |t|
+      t.references :offer
+      t.references :gender
+    end
+    add_index(:offer_genders, [:gender_id, :offer_id], unique: true)
+  end
+end

--- a/db/migrate/20231218105556_remove_target_gender_from_offers.rb
+++ b/db/migrate/20231218105556_remove_target_gender_from_offers.rb
@@ -1,0 +1,5 @@
+class RemoveTargetGenderFromOffers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :offers, :target_gender, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_17_042344) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_18_105556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,21 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_17_042344) do
     t.index ["player_id"], name: "index_claimed_offers_on_player_id"
   end
 
+  create_table "genders", force: :cascade do |t|
+    t.string "name"
+    t.string "label"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "offer_genders", force: :cascade do |t|
+    t.bigint "offer_id"
+    t.bigint "gender_id"
+    t.index ["gender_id", "offer_id"], name: "index_offer_genders_on_gender_id_and_offer_id", unique: true
+    t.index ["gender_id"], name: "index_offer_genders_on_gender_id"
+    t.index ["offer_id"], name: "index_offer_genders_on_offer_id"
+  end
+
   create_table "offer_tags", force: :cascade do |t|
     t.bigint "tag_id"
     t.bigint "offer_id"
@@ -56,7 +71,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_17_042344) do
     t.integer "min_age"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "target_gender"
     t.index ["target_age"], name: "index_offers_on_target_age"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,6 +8,16 @@ FactoryBot.define do
     name {Faker::Marketing.buzzwords.first(20).split("").shuffle.join}
   end
 
+  factory :female_gender, class: Gender do
+    name {'female'}
+    label {'Female'}
+  end 
+
+  factory :male_gender, class: Gender do
+    name {'male'}
+    label {'Male'}
+  end   
+
   factory :new_player, class: Player do
     email {Faker::Internet.email}
     password {"password"}
@@ -17,29 +27,33 @@ FactoryBot.define do
 
   factory :new_offer, class: Offer do 
     title {"Test Offer"}
-    description {"Test description for a test offer."}
-    target_gender {"female"}
+    description {"Test description for a test offer."} 
     target_age {35}
     min_age {30}
     max_age {40}
+    after(:create) do |offer|
+      offer.target_genders << [FactoryBot.create(:female_gender)]
+    end    
   end
 
   factory :male_offer, class: Offer do 
     title {"Test Offer"}
     description {"Test description for a test offer."}
-    target_gender {"male"}
     target_age {35}
     min_age {30}
     max_age {40}
+    after(:create) do |offer|
+      offer.target_genders << [FactoryBot.create(:male_gender)]
+    end
   end  
 
-  factory :random_offer, class: Offer do 
-    title {"Test Offer"}
-    description {"Test description for a test offer."}
-    target_gender {["female", "male", "nonbinary", 'declined'].sample}
-    target_age {generate_age_range}
-    min_age {(18..34).to_a.sample}
-    max_age {(36..60).to_a.sample}
-  end  
+  # factory :random_offer, class: Offer do 
+  #   title {"Test Offer"}
+  #   description {"Test description for a test offer."}
+  #   target_gender {["female", "male", "nonbinary", 'declined'].sample}
+  #   target_age {generate_age_range}
+  #   min_age {(18..34).to_a.sample}
+  #   max_age {(36..60).to_a.sample}
+  # end  
 
 end

--- a/spec/models/associations/offer_gender_spec.rb
+++ b/spec/models/associations/offer_gender_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe OfferGender, type: :model do
+  describe 'columns' do 
+    it { is_expected.to have_db_column(:gender_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:offer_id).of_type(:integer) }
+  end
+
+  describe 'associations' do 
+    it { should belong_to(:gender) }
+    it { should belong_to(:offer) }
+  end
+  
+end

--- a/spec/models/gender_spec.rb
+++ b/spec/models/gender_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Gender, type: :model do
+  describe 'columns' do
+    it { is_expected.to have_db_column(:name).of_type(:string) }
+  end
+
+  describe 'associations' do 
+    it {should have_many(:offers)}
+  end  
+
+  describe 'validations' do 
+    it { should validate_presence_of(:name) }
+
+    before(:each) do 
+      @gender = Gender.create(name: "female", label: "Female")
+    end
+
+    context "name" do 
+      it "should error out if not in whitelist" do
+        @gender.name = "none"
+        expect(@gender.valid?).to eq(false)
+        expect{@gender.save!}.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "should save if present in the whitelist" do
+        Gender::GENDERS.each do |gender|
+          @gender.name = gender
+          expect(@gender.valid?).to eq(true)
+          expect(@gender.save!).to eq(true)          
+        end        
+      end   
+    end
+
+    context "label" do 
+      it "should error out if not in whitelist" do
+        @gender.label = "famle"
+        expect(@gender.valid?).to eq(false)
+        expect{@gender.save!}.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "should save if present in the whitelist" do
+        Gender::LABELS.each do |label|
+          @gender.label = label
+          expect(@gender.valid?).to eq(true)
+          expect(@gender.save!).to eq(true)          
+        end        
+      end   
+    end 
+
+  end
+end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Offer, type: :model do
     it { is_expected.to have_db_column(:title).of_type(:string) }
     it { is_expected.to have_db_column(:description).of_type(:text) }
     it { is_expected.to have_db_column(:target_age).of_type(:integer) }
-    it { is_expected.to have_db_column(:target_gender).of_type(:string) }
     it { is_expected.to have_db_column(:max_age).of_type(:integer) }
     it { is_expected.to have_db_column(:min_age).of_type(:integer) }
   end  
 
   describe 'associations' do 
+    it {should have_many(:target_genders)}
     it {should have_many(:claimed_offers)}
     it {should have_many(:players)}
     it {should have_many(:tags)}
@@ -35,25 +35,7 @@ RSpec.describe Offer, type: :model do
 
     before(:each) do 
       @offer = FactoryBot.build(:new_offer)
-    end
-
-    context "target_gender" do
-
-      it "should error out if not in whitelist" do
-        @offer.target_gender = "none"
-        expect(@offer.valid?).to eq(false)
-        expect{@offer.save!}.to raise_error(ActiveRecord::RecordInvalid)
-      end
-
-      it "should save if present in the whitelist" do
-        Offer::GENDERS.each do |target_gender|
-          @offer.target_gender = target_gender
-          expect(@offer.valid?).to eq(true)
-          expect(@offer.save!).to eq(true)          
-        end        
-      end 
-
-    end    
+    end 
 
     context "target_age" do 
       it "should be valid if in range" do 
@@ -111,41 +93,6 @@ RSpec.describe Offer, type: :model do
       4.times do 
         FactoryBot.create(:male_offer)
       end         
-    end
-
-    context '#in_age_range' do 
-      it "will pull by age range" do 
-        offers = Offer.in_age_range(35)
-        offers.each do |offer|
-          expect(offer.min_age < 35).to eq(true)
-          expect(offer.max_age > 35).to eq(true)
-        end
-      end
-    end
-
-    context '#targeting' do 
-      it '#targeting will pull by gender' do 
-        female_offers = Offer.targeting("female")
-        expect(female_offers.length >= 4).to eq(true)
-      end
-
-      it '#targeting will pull by gender' do 
-        other_offers = Offer.not_targeting("female")
-        other_offers.each do |offer|
-          expect(offer.target_gender).to_not eq("female")  
-        end
-      end  
-    end 
-
-    context 'combinatory' do 
-      it "will pull by age range and gender when chained" do 
-        offers = Offer.targeting("female").in_age_range(35)
-        offers.each do |offer|
-          expect(offer.min_age < 35).to eq(true)
-          expect(offer.max_age > 35).to eq(true)
-          expect(offer.target_gender).to eq("female")
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
I think I may have over-interpreted the doc and freaked out a little, but you can now assign multiple genders to an Offer for targeting.

Honestly, the real MVP here is my test suite. This didn't take me very long to change, and the code I DID have to change was built in a way that easily allowed arrays versus a single value.

I built this thing well. I was super happy to be able to do this THAT quickly.